### PR TITLE
Fix a compilation bug at CUDA 9.0

### DIFF
--- a/src/alg/totem_stress.cu
+++ b/src/alg/totem_stress.cu
@@ -386,7 +386,7 @@ error_t stress_unweighted_cpu(const graph_t* graph,
             delta[v] += 1 + delta[u];
           }
         }
-      }
+      };
       OMP(omp parallel for)
       for (vid_t v = 0; v < graph->vertex_count; v++) {
         if (v != source && dists[v] == dist) {


### PR DESCRIPTION
Just add a semicolon to fix  "compilation error at src/alg/totem_stress.cu:391".
I know this semicolon seems totally unnecessary, but it just works and doesn't cost a lot.